### PR TITLE
fix issue/17

### DIFF
--- a/tutorial/chapter3.lisp
+++ b/tutorial/chapter3.lisp
@@ -347,8 +347,8 @@
         (gethash #\+ *binop-precedence*) 20
         (gethash #\- *binop-precedence*) 30
         (gethash #\* *binop-precedence*) 40)
-  (llvm:with-objects ((*builder* 'llvm:builder)
-                      (*module* 'llvm:module :name "my cool jit"))
+  (llvm:with-objects ((*builder* llvm:builder)
+                      (*module* llvm:module :name "my cool jit"))
     (format *error-output* "~&ready> ")
     (get-next-token)
     (main-loop)

--- a/tutorial/chapter4.lisp
+++ b/tutorial/chapter4.lisp
@@ -359,11 +359,10 @@
         (gethash #\+ *binop-precedence*) 20
         (gethash #\- *binop-precedence*) 30
         (gethash #\* *binop-precedence*) 40)
-  (llvm:with-objects ((*builder* 'llvm:builder)
-                      (*module* 'llvm:module :name "my cool jit")
-                      (*execution-engine* 'llvm:execution-engine
-                                          :module *module*)
-                      (*fpm* 'llvm:function-pass-manager :module *module*))
+  (llvm:with-objects ((*builder* llvm:builder)
+                      (*module* llvm:module :name "my cool jit")
+                      (*execution-engine* llvm:execution-engine *module*)
+                      (*fpm* llvm:function-pass-manager *module*))
     (llvm:add-target-data (llvm:target-data *execution-engine*) *fpm*)
     (llvm:add-instruction-combining-pass *fpm*)
     (llvm:add-reassociate-pass *fpm*)

--- a/tutorial/chapter5.lisp
+++ b/tutorial/chapter5.lisp
@@ -518,11 +518,10 @@
         (gethash #\+ *binop-precedence*) 20
         (gethash #\- *binop-precedence*) 30
         (gethash #\* *binop-precedence*) 40)
-  (llvm:with-objects ((*builder* 'llvm:builder)
-                      (*module* 'llvm:module :name "my cool jit")
-                      (*execution-engine* 'llvm:execution-engine
-                                          :module *module*)
-                      (*fpm* 'llvm:function-pass-manager :module *module*))
+  (llvm:with-objects ((*builder* llvm:builder)
+                      (*module* llvm:module :name "my cool jit")
+                      (*execution-engine* llvm:execution-engine *module*)
+                      (*fpm* llvm:function-pass-manager *module*))
     (llvm:add-target-data (llvm:target-data *execution-engine*) *fpm*)
     (llvm:add-instruction-combining-pass *fpm*)
     (llvm:add-reassociate-pass *fpm*)

--- a/tutorial/chapter6.lisp
+++ b/tutorial/chapter6.lisp
@@ -597,11 +597,10 @@
         (gethash #\+ *binop-precedence*) 20
         (gethash #\- *binop-precedence*) 30
         (gethash #\* *binop-precedence*) 40)
-  (llvm:with-objects ((*builder* 'llvm:builder)
-                      (*module* 'llvm:module :name "my cool jit")
-                      (*execution-engine* 'llvm:execution-engine
-                                          :module *module*)
-                      (*fpm* 'llvm:function-pass-manager :module *module*))
+  (llvm:with-objects ((*builder* llvm:builder)
+                      (*module* llvm:module :name "my cool jit")
+                      (*execution-engine* llvm:execution-engine *module*)
+                      (*fpm* llvm:function-pass-manager *module*))
     (llvm:add-target-data (llvm:target-data *execution-engine*) *fpm*)
     (llvm:add-instruction-combining-pass *fpm*)
     (llvm:add-reassociate-pass *fpm*)

--- a/tutorial/chapter7.lisp
+++ b/tutorial/chapter7.lisp
@@ -685,11 +685,10 @@
         (gethash #\+ *binop-precedence*) 20
         (gethash #\- *binop-precedence*) 30
         (gethash #\* *binop-precedence*) 40)
-  (llvm:with-objects ((*builder* 'llvm:builder)
-                      (*module* 'llvm:module :name "my cool jit")
-                      (*execution-engine* 'llvm:execution-engine
-                                          :module *module*)
-                      (*fpm* 'llvm:function-pass-manager :module *module*))
+  (llvm:with-objects ((*builder* llvm:builder)
+                      (*module* llvm:module :name "my cool jit")
+                      (*execution-engine* llvm:execution-engine *module*)
+                      (*fpm* llvm:function-pass-manager *module*))
     (llvm:add-target-data (llvm:target-data *execution-engine*) *fpm*)
     (llvm:add-promote-memory-to-register-pass *fpm*)
     (llvm:add-instruction-combining-pass *fpm*)


### PR DESCRIPTION
This pr can fix #17 and this make `with-object` to be able to take both of
```Lisp
(llvm:with-object (*builder* 'llvm:builder)
  ...)

;; or
(llvm:with-object (*builder* llvm:builder)
  ...)
```
.

If you have the idea about which style `with-object` should be, feel free to ask me to fix pr.