### PR TITLE
Specify the relative path to libkaleidoscope.

### DIFF
--- a/tutorial/cffi.lisp
+++ b/tutorial/cffi.lisp
@@ -1,6 +1,8 @@
 ;;; This just makes sure the library gets loaded for use by LLVM
 
 (cffi:define-foreign-library libkaleidoscope
-  (t (:default "tutorial/.libs/libkaleidoscope")))
+  (t (:default #.(namestring
+                  (asdf:system-relative-pathname :kaleidoscope
+                                                 "tutorial/.libs/libkaleidoscope")))))
 
 (cffi:use-foreign-library libkaleidoscope)


### PR DESCRIPTION
No need to change the current directory to the project root by this patch.