### PR TITLE
Add llvm:print-value-to-string (LLVMPrintValueToString).

### DIFF
--- a/src/core/values.lisp
+++ b/src/core/values.lisp
@@ -11,6 +11,8 @@
   (finish-output *error-output*)
   (%dump-value val))
 
+(defcfun* "LLVMPrintValueToString" :string (val value))
+
 (defcfun* "LLVMGetOperand" value (val value) (index :unsigned-int))
 (defcfun* "LLVMSetOperand" value (user value) (index :unsigned-int) (val value))
 (defcfun* "LLVMGetNumOperands" value (val value))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -66,7 +66,7 @@
            #:type-handle #:refine-type #:resolve-type-handle
            #:dispose-type-handle
            ;; values
-           #:type-of #:value-name #:dump-value
+           #:type-of #:value-name #:dump-value #:print-value-to-string
            #:get-operand #:set-operand #:get-num-operands
            #:const-null #:const-all-ones #:undef #:constantp #:nullp #:undefp
            #:const-pointer-null


### PR DESCRIPTION
It's like `llvm:dump-value` except it returns the IR as a string, instead to STDERR.

ref. http://llvm.org/docs/doxygen/html/group__LLVMCCoreValueGeneral.html#ga283f3487d0e658c58d3da00083a8d966